### PR TITLE
Add footer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ spec
 .pairs
 .travis.yml
 .npmignore
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "less-cache",
   "version": "0.20.0",
-  "description": "LESS compile cache",
+  "description": "Less compile cache",
   "main": "./lib/less-cache",
   "scripts": {
     "prepublish": "grunt clean lint coffee",

--- a/spec/fixtures/footer.less
+++ b/spec/fixtures/footer.less
@@ -1,0 +1,5 @@
+@import "a";
+
+body {
+  a: @a;
+}

--- a/spec/less-cache-spec.coffee
+++ b/spec/less-cache-spec.coffee
@@ -42,7 +42,7 @@ describe "LessCache", ->
     beforeEach ->
       filePath = join(fixturesDir, 'imports.less')
 
-    it "returns the compiled CSS for a given path and LESS content", ->
+    it "returns the compiled CSS for a given path and Less content", ->
       css = cache.cssForFile(filePath, fileLess)
       expect(css).toBe """
         body {
@@ -62,7 +62,7 @@ describe "LessCache", ->
       expect(cache.stats.hits).toBe 0
       expect(cache.stats.misses).toBe 1
 
-    it "returns the compiled CSS for a given LESS file path", ->
+    it "returns the compiled CSS for a given Less file path", ->
       expect(css).toBe """
         body {
           a: 1;
@@ -73,7 +73,7 @@ describe "LessCache", ->
 
       """
 
-    it "returns the cached CSS for a given LESS file path", ->
+    it "returns the cached CSS for a given Less file path", ->
       spyOn(cache, 'parseLess').andCallThrough()
       expect(cache.readFileSync(join(fixturesDir, 'imports.less'))).toBe """
         body {

--- a/spec/less-cache-spec.coffee
+++ b/spec/less-cache-spec.coffee
@@ -274,6 +274,28 @@ describe "LessCache", ->
         expect(cache3.stats.misses).toBe 1
         expect(cache3.stats.hits).toBe 0
 
+      it "returns cached content when a fallback directory is present", ->
+        filePath = join(fixturesDir, 'footer.less')
+
+        cache2 = new LessCache
+          cacheDir: join(dirname(cache.getDirectory()), 'cache2')
+          importPaths: cache.getImportPaths()
+          fallbackDir: cache.getDirectory()
+          resourcePath: fixturesDir
+        cache2.setFooter(filePath, '\n@a: 2;')
+        cache2.readFileSync(filePath)
+
+        cache3 = new LessCache
+          cacheDir: join(dirname(cache.getDirectory()), 'cache3')
+          importPaths: cache2.getImportPaths()
+          fallbackDir: cache2.getDirectory()
+          resourcePath: fixturesDir
+        cache3.setFooter(filePath, '\n@a: 2;')
+
+        cache3.readFileSync(filePath)
+        expect(cache3.stats.misses).toBe 0
+        expect(cache3.stats.hits).toBe 1
+
     describe "when the footer is for a file that is imported", ->
       it "appends the footer to the imported file", ->
         filePath = join(fixturesDir, 'footer.less')
@@ -329,3 +351,26 @@ describe "LessCache", ->
         """
         expect(cache3.stats.misses).toBe 1
         expect(cache3.stats.hits).toBe 0
+
+      it "returns cached content when a fallback directory is present", ->
+        filePath = join(fixturesDir, 'footer.less')
+        importPath = join(fixturesDir, 'a.less')
+
+        cache2 = new LessCache
+          cacheDir: join(dirname(cache.getDirectory()), 'cache2')
+          importPaths: cache.getImportPaths()
+          fallbackDir: cache.getDirectory()
+          resourcePath: fixturesDir
+        cache2.setFooter(importPath, '\n@a: 2;')
+        cache2.readFileSync(filePath)
+
+        cache3 = new LessCache
+          cacheDir: join(dirname(cache.getDirectory()), 'cache3')
+          importPaths: cache2.getImportPaths()
+          fallbackDir: cache2.getDirectory()
+          resourcePath: fixturesDir
+        cache3.setFooter(importPath, '\n@a: 2;')
+
+        cache3.readFileSync(filePath)
+        expect(cache3.stats.misses).toBe 0
+        expect(cache3.stats.hits).toBe 1

--- a/spec/less-cache-spec.coffee
+++ b/spec/less-cache-spec.coffee
@@ -219,11 +219,11 @@ describe "LessCache", ->
       cache3.readFileSync(join(fixturesDir, 'imports.less'))
       expect(cache3.parseLess.callCount).toBe 0
 
-  describe "addFooter(filePath, footer)", ->
+  describe "setFooter(filePath, footer)", ->
     describe "when the footer is for a file that is directly read", ->
       it "appends the footer to the file", ->
         filePath = join(fixturesDir, 'footer.less')
-        cache.addFooter(filePath, '\n@a: 2;')
+        cache.setFooter(filePath, '\n@a: 2;')
 
         css = cache.readFileSync(filePath)
         expect(css).toBe """
@@ -249,7 +249,7 @@ describe "LessCache", ->
       it "appends the footer to the imported file", ->
         filePath = join(fixturesDir, 'footer.less')
         importPath = join(fixturesDir, 'a.less')
-        cache.addFooter(importPath, '\n@a: 2;')
+        cache.setFooter(importPath, '\n@a: 2;')
 
         css = cache.readFileSync(filePath)
         expect(css).toBe """

--- a/spec/less-cache-spec.coffee
+++ b/spec/less-cache-spec.coffee
@@ -218,3 +218,55 @@ describe "LessCache", ->
       spyOn(cache3, 'parseLess').andCallThrough()
       cache3.readFileSync(join(fixturesDir, 'imports.less'))
       expect(cache3.parseLess.callCount).toBe 0
+
+  describe "addFooter(filePath, footer)", ->
+    describe "when the footer is for a file that is directly read", ->
+      it "appends the footer to the file", ->
+        filePath = join(fixturesDir, 'footer.less')
+        cache.addFooter(filePath, '\n@a: 2;')
+
+        css = cache.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 2;
+          }
+
+        """
+        expect(cache.stats.misses).toBe 1
+        expect(cache.stats.hits).toBe 0
+
+        css = cache.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 2;
+          }
+
+        """
+        expect(cache.stats.misses).toBe 1
+        expect(cache.stats.hits).toBe 1
+
+    describe "when the footer is for a file that is imported", ->
+      it "appends the footer to the imported file", ->
+        filePath = join(fixturesDir, 'footer.less')
+        importPath = join(fixturesDir, 'a.less')
+        cache.addFooter(importPath, '\n@a: 2;')
+
+        css = cache.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 2;
+          }
+
+        """
+        expect(cache.stats.misses).toBe 1
+        expect(cache.stats.hits).toBe 0
+
+        css = cache.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 2;
+          }
+
+        """
+        expect(cache.stats.misses).toBe 1
+        expect(cache.stats.hits).toBe 1

--- a/spec/less-cache-spec.coffee
+++ b/spec/less-cache-spec.coffee
@@ -245,6 +245,35 @@ describe "LessCache", ->
         expect(cache.stats.misses).toBe 1
         expect(cache.stats.hits).toBe 1
 
+      it "returns cached content across different cache instances", ->
+        filePath = join(fixturesDir, 'footer.less')
+        cache.setFooter(filePath, '\n@a: 2;')
+        cache.readFileSync(filePath)
+
+        cache2 = new LessCache(cacheDir: cache.getDirectory(), importPaths: cache.getImportPaths())
+        cache2.setFooter(filePath, '\n@a: 2;')
+
+        css = cache2.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 2;
+          }
+
+        """
+        expect(cache2.stats.misses).toBe 0
+        expect(cache2.stats.hits).toBe 1
+
+        cache3 = new LessCache(cacheDir: cache.getDirectory(), importPaths: cache.getImportPaths())
+        css = cache3.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 1;
+          }
+
+        """
+        expect(cache3.stats.misses).toBe 1
+        expect(cache3.stats.hits).toBe 0
+
     describe "when the footer is for a file that is imported", ->
       it "appends the footer to the imported file", ->
         filePath = join(fixturesDir, 'footer.less')
@@ -270,3 +299,33 @@ describe "LessCache", ->
         """
         expect(cache.stats.misses).toBe 1
         expect(cache.stats.hits).toBe 1
+
+      it "returns cached content across different cache instances", ->
+        filePath = join(fixturesDir, 'footer.less')
+        importPath = join(fixturesDir, 'a.less')
+        cache.setFooter(importPath, '\n@a: 2;')
+        cache.readFileSync(filePath)
+
+        cache2 = new LessCache(cacheDir: cache.getDirectory(), importPaths: cache.getImportPaths())
+        cache2.setFooter(importPath, '\n@a: 2;')
+
+        css = cache2.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 2;
+          }
+
+        """
+        expect(cache2.stats.misses).toBe 0
+        expect(cache2.stats.hits).toBe 1
+
+        cache3 = new LessCache(cacheDir: cache.getDirectory(), importPaths: cache.getImportPaths())
+        css = cache3.readFileSync(filePath)
+        expect(css).toBe """
+          body {
+            a: 1;
+          }
+
+        """
+        expect(cache3.stats.misses).toBe 1
+        expect(cache3.stats.hits).toBe 0

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -199,6 +199,7 @@ class LessCache
   #
   # Returns the compiled CSS for the given path and lessContent
   cssForFile: (filePath, lessContent) ->
+    lessContent += @getFooter(filePath)
     digest = @digestForContent(lessContent)
     css = @getCachedCss(filePath, digest)
     if css?

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -90,8 +90,8 @@ class LessCache
     originalFsReadFileSync = nodeFs.readFileSync
     nodeFs.readFileSync = (filePath, args...) =>
       content = originalFsReadFileSync(filePath, args...)
-      filePath = @relativize(@resourcePath, filePath) if @resourcePath
       content += @getFooter(filePath)
+      filePath = @relativize(@resourcePath, filePath) if @resourcePath
       importedPaths.push({path: filePath, digest: @digestForContent(content)})
       content
 
@@ -178,6 +178,13 @@ class LessCache
   # Returns undefined.
   setFooter: (filePath, footer) ->
     @footers[filePath] = footer
+    return
+
+  # Remove all the footers from the cache.
+  #
+  # Returns undefined.
+  clearFooters: ->
+    @footers = {}
     return
 
   # Read the Less file at the current path and return either the cached CSS or the newly

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -11,12 +11,12 @@ cacheVersion = 1
 
 module.exports =
 class LessCache
-  # Create a new LESS cache with the given options.
+  # Create a new Less cache with the given options.
   #
   # options - An object with following keys
   #   * cacheDir: A string path to the directory to store cached files in (required)
   #
-  #   * importPaths: An array of strings to configure the LESS parser with (optional)
+  #   * importPaths: An array of strings to configure the Less parser with (optional)
   #
   #   * resourcePath: A string path to use for relativizing paths. This is useful if
   #                   you want to make caches transferable between directories or
@@ -172,11 +172,11 @@ class LessCache
     @footers[filePath] = footer
     return
 
-  # Read the LESS file at the current path and return either the cached CSS or the newly
+  # Read the Less file at the current path and return either the cached CSS or the newly
   # compiled CSS. This method caches the compiled CSS after it is generated. This cached
-  # CSS will be returned as long as the LESS file and any of its imports are unchanged.
+  # CSS will be returned as long as the Less file and any of its imports are unchanged.
   #
-  # filePath: A string path to a LESS file.
+  # filePath: A string path to a Less file.
   #
   # Returns the compiled CSS for the given path.
   readFileSync: (filePath) ->
@@ -184,9 +184,9 @@ class LessCache
 
   # Return either cached CSS or the newly
   # compiled CSS from `lessContent`. This method caches the compiled CSS after it is generated. This cached
-  # CSS will be returned as long as the LESS file and any of its imports are unchanged.
+  # CSS will be returned as long as the Less file and any of its imports are unchanged.
   #
-  # filePath: A string path to the LESS file.
+  # filePath: A string path to the Less file.
   # lessContent: The contents of the filePath
   #
   # Returns the compiled CSS for the given path and lessContent

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -168,6 +168,14 @@ class LessCache
   getFooter: (filePath) ->
     @footers[filePath] ? ''
 
+  # Add a string footer that should be added to the Less content at the file
+  # path whenever this is read. This is useful for adding dynamic variables
+  #
+  # filePath: A string path to a Less file.
+  # footer: A string of Less content to add to the end of the file when it is
+  #         read.
+  #
+  # Returns undefined.
   addFooter: (filePath, footer) ->
     @footers[filePath] = footer
     return

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -176,7 +176,7 @@ class LessCache
   #         read.
   #
   # Returns undefined.
-  addFooter: (filePath, footer) ->
+  setFooter: (filePath, footer) ->
     @footers[filePath] = footer
     return
 

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -168,7 +168,7 @@ class LessCache
   getFooter: (filePath) ->
     @footers[filePath] ? ''
 
-  # Add a string footer that should be added to the Less content at the file
+  # Set the string footer that should be added to the Less content at the file
   # path whenever this is read. This is useful for adding dynamic variables
   #
   # filePath: A string path to a Less file.

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -153,7 +153,6 @@ class LessCache
 
   parseLess: (filePath, less) ->
     css = null
-    less += @getFooter(filePath)
     options = filename: filePath, syncImport: true, paths: @importPaths
     Parser ?= require('less').Parser
     parser = new Parser(options)


### PR DESCRIPTION
This adds support for adding dynamic content to stylesheets that will be appended to the stylesheet when read from disk.

`setFooter(filePath, content)` will add the given Less content to the bottom of the file at the path when it is read.

This will allow theme settings in https://github.com/atom/atom/pull/4153