### PR TITLE
Upgrade packages that use old versions of graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "fs-plus": "2.x"
   },
   "devDependencies": {
-    "jasmine-focused": "1.x",
-    "tmp": "0.0.28",
     "fstream": "^1.0.10",
-    "grunt-contrib-coffee": "^1.0.0",
-    "grunt-cli": "^1.2.0",
     "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-coffeelint": "0.0.16",
+    "grunt-contrib-coffee": "^1.0.0",
     "grunt-shell": "^1.3.0",
-    "grunt-coffeelint": "0.0.16"
+    "jasmine-focused": "1.x",
+    "tmp": "0.0.28"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   },
   "devDependencies": {
     "jasmine-focused": "1.x",
-    "tmp": "0.0.21",
-    "fstream": "~0.1.24",
-    "grunt-contrib-coffee": "~0.9.0",
-    "grunt-cli": "~0.1.9",
-    "grunt": "~0.4.1",
-    "grunt-shell": "~0.3.1",
-    "grunt-coffeelint": "0.0.7"
+    "tmp": "0.0.28",
+    "fstream": "^1.0.10",
+    "grunt-contrib-coffee": "^1.0.0",
+    "grunt-cli": "^1.2.0",
+    "grunt": "^1.0.1",
+    "grunt-shell": "^1.3.0",
+    "grunt-coffeelint": "0.0.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     }
   ],
   "dependencies": {
+    "fs-plus": "2.x",
     "less": "^2.7.1",
     "underscore-plus": "1.x",
-    "walkdir": "0.0.11",
-    "fs-plus": "2.x"
+    "walkdir": "0.0.11"
   },
   "devDependencies": {
     "fstream": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "dependencies": {
-    "less": "^1.7.5",
+    "less": "^2.7.1",
     "underscore-plus": "1.x",
     "walkdir": "0.0.7",
     "fs-plus": "2.x"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "less": "^2.7.1",
     "underscore-plus": "1.x",
-    "walkdir": "0.0.7",
+    "walkdir": "0.0.11",
     "fs-plus": "2.x"
   },
   "devDependencies": {

--- a/src/less-cache.coffee
+++ b/src/less-cache.coffee
@@ -3,8 +3,8 @@ crypto = require 'crypto'
 
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
+less = null # Defer until it is actually used
 lessFs = null # Defer until it is actually used
-Parser = null # Defer until it is actually used
 walkdir = require('walkdir').sync
 
 cacheVersion = 1
@@ -85,7 +85,7 @@ class LessCache
 
   observeImportedFilePaths: (callback) ->
     importedPaths = []
-    lessFs ?= require 'less/lib/less/fs.js'
+    lessFs ?= require 'less/lib/less-node/fs.js'
     originalFsReadFileSync = lessFs.readFileSync
     lessFs.readFileSync = (filePath, args...) =>
       content = originalFsReadFileSync(filePath, args...)
@@ -157,17 +157,16 @@ class LessCache
     if @syncCaches and @importsFallbackDir?
       @writeJson(@getCachePath(@importsFallbackDir, filePath), cacheEntry)
 
-  parseLess: (filePath, less) ->
+  parseLess: (filePath, contents) ->
     css = null
     options = filename: filePath, syncImport: true, paths: @importPaths
-    Parser ?= require('less').Parser
-    parser = new Parser(options)
-    imports = @observeImportedFilePaths =>
-      parser.parse less, (error, tree) =>
+    less ?= require('less')
+    imports = @observeImportedFilePaths ->
+      less.render contents, options, (error, result) ->
         if error?
           throw error
         else
-          css = tree.toCSS()
+          {css} = result
     {imports, css}
 
   # Read the Less file at the current path and return either the cached CSS or the newly


### PR DESCRIPTION
The main upgrades here are the various Grunt packages and Less.js, all of which relied on deprecated versions of graceful-fs. Node.js v6 and later requires graceful-fs v4 (or newer).

I also bumped the other packages, and alphabetized the package lists in `package.json`.

This PR is required as part of https://github.com/atom/atom/pull/12176.
/cc @atom/feedback @kevinsawicki @nathansobo 