### PR TITLE
Use the provided less sources instead of reading them from disk 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-contrib-coffee": "^1.0.0",
     "grunt-shell": "^1.3.0",
     "jasmine-focused": "1.x",
+    "temp": "^0.8.3",
     "tmp": "0.0.28"
   }
 }


### PR DESCRIPTION
When supplying the `lessSourcesByRelativeFilePath` and `resourcePath` variables, we will now check whether we can read from the provided in-memory source cache and, as a result, avoid unnecessary reads from the file system for style sheets that haven't changed and that we know are bundled in Atom.

/cc: @nathansobo 